### PR TITLE
docs: use go install instead go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Interested in managing your git repositiories in a similar way? Checkout [mani](
 
 * Via GO install
     ```sh
-    go get -u github.com/alajmo/sake
+    go install github.com/alajmo/sake@latest
     ```
 
 Auto-completion is available via `sake completion bash|zsh|fish` and man page via `sake gen`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,7 +17,7 @@
 
 * via Go
   ```bash
-  go get -u github.com/alajmo/sake
+  go install github.com/alajmo/sake@latest
   ```
 
 ## Building From Source


### PR DESCRIPTION
use go install instead go get for binary installation