### PR TITLE
Fix too many auth connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ update-golden-files:
 mock-ssh:
 	cd ./test && docker-compose up
 
+mock-performance-ssh:
+	cd ./test && docker-compose -f docker-compose-performance.yaml up
+
 build:
 	CGO_ENABLED=0 go build \
 	-ldflags "-s -w -X '${PACKAGE}/cmd.version=${VERSION}' -X '${PACKAGE}/cmd.commit=${GIT}' -X '${PACKAGE}/cmd.date=${DATE}'" \

--- a/core/dao/server.go
+++ b/core/dao/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	WorkDir      string
 	IdentityFile *string
 	Password     *string
+	AuthMethod   string
 
 	context     string // config path
 	contextLine int    // defined at
@@ -45,6 +46,7 @@ type ServerYAML struct {
 	WorkDir      string    `yaml:"work_dir"`
 	IdentityFile *string   `yaml:"identity_file"`
 	Password     *string   `yaml:"password"`
+	AuthMethod   string    `yaml:"-"`
 }
 
 func (s Server) GetValue(key string, _ int) string {
@@ -186,6 +188,16 @@ func (c *ConfigYAML) ParseServersYAML() ([]Server, []ResourceErrors[Server]) {
 
 		if serverYAML.Password != nil {
 			server.Password = serverYAML.Password
+		}
+
+		if server.IdentityFile != nil && server.Password != nil {
+			server.AuthMethod = "password-key"
+		} else if server.IdentityFile != nil {
+			server.AuthMethod = "key"
+		} else if server.Password != nil {
+			server.AuthMethod = "password"
+		} else {
+			server.AuthMethod = "none"
 		}
 
 		servers = append(servers, *server)

--- a/core/run/client.go
+++ b/core/run/client.go
@@ -28,3 +28,8 @@ type ErrConnect struct {
 	Port   uint16
 	Reason string
 }
+
+func (e *ErrConnect) Error() string {
+	return ""
+}
+

--- a/core/run/client.go
+++ b/core/run/client.go
@@ -32,4 +32,3 @@ type ErrConnect struct {
 func (e *ErrConnect) Error() string {
 	return ""
 }
-

--- a/core/run/exec.go
+++ b/core/run/exec.go
@@ -175,7 +175,7 @@ func (run *Run) SetClients(
 	createRemoteClient := func(authMethod ssh.AuthMethod, server dao.Server, wg *sync.WaitGroup, mu *sync.Mutex) {
 		defer wg.Done()
 
-		// PASSWORD ONLY?
+		// TODO: Did i already evalute the password?
 		var auth ssh.AuthMethod
 		if server.IdentityFile == nil && server.Password != nil {
 			// Password only logic
@@ -228,6 +228,12 @@ func (run *Run) SetClients(
 	}
 
 	for _, server := range run.Servers {
+	}
+
+	// Loop through servers and find the identity file, then create a hashmap with string -> signer
+	// Loop through servers and fetch the signer from the previous hashmap and connect
+
+	for _, server := range run.Servers {
 		wg.Add(1)
 		go createLocalClient(server, &wg, &mu)
 
@@ -237,7 +243,6 @@ func (run *Run) SetClients(
 			var signers []ssh.Signer
 			identitySigner, err := GetIdentitySigner(server)
 			if err != nil {
-				fmt.Println(123)
 				return []ErrConnect{*err}, nil
 			}
 

--- a/core/run/exec.go
+++ b/core/run/exec.go
@@ -204,11 +204,6 @@ func (run *Run) SetClients(
 		return []ErrConnect{}, err
 	}
 
-	// Loop through servers and find the identity file,
-	// then create a hashmap with string -> signer
-	// Loop through servers and fetch the signer from the previous hashmap and connect
-
-	// TODO: Check errors
 	identities := make(map[string]ssh.Signer)
 	passwordAuthMethods := make(map[string]ssh.AuthMethod)
 	for _, server := range run.Servers {
@@ -242,7 +237,6 @@ func (run *Run) SetClients(
 		}
 	}
 
-	// TODO: Check errors
 	for _, server := range run.Servers {
 		wg.Add(1)
 		go createLocalClient(server, &wg, &mu)

--- a/core/run/ssh.go
+++ b/core/run/ssh.go
@@ -163,6 +163,7 @@ func GetIdentitySigner(server dao.Server) (ssh.Signer, *ErrConnect) {
 		}
 
 		if pass != nil {
+			// Password protected key
 			signer, err = ssh.ParsePrivateKeyWithPassphrase(data, []byte(*pass))
 			if err != nil {
 				errConnect := &ErrConnect{
@@ -175,6 +176,7 @@ func GetIdentitySigner(server dao.Server) (ssh.Signer, *ErrConnect) {
 				return nil, errConnect
 			}
 		} else {
+			// Unprotected key
 			signer, err = ssh.ParsePrivateKey(data)
 			if err != nil {
 				errConnect := &ErrConnect{

--- a/test/docker-compose-performance.yaml
+++ b/test/docker-compose-performance.yaml
@@ -1,0 +1,97 @@
+---
+version: "3.9"
+
+services:
+  server-1:
+    container_name: "server-1"
+    build: .
+    ports:
+      - "222:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.2
+
+  server-2:
+    container_name: "server-2"
+    build: .
+    ports:
+      - "223:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.3
+
+  server-3:
+    container_name: "server-3"
+    build: .
+    ports:
+      - "224:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.4
+
+  server-4:
+    container_name: "server-4"
+    build: .
+    ports:
+      - "225:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.5
+
+  server-5:
+    container_name: "server-5"
+    build: .
+    ports:
+      - "226:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.6
+
+  server-6:
+    container_name: "server-6"
+    build: .
+    ports:
+      - "227:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.7
+
+  server-7:
+    container_name: "server-7"
+    build: .
+    ports:
+      - "228:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.8
+
+  server-8:
+    container_name: "server-8"
+    build: .
+    ports:
+      - "229:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.9
+
+  server-9:
+    container_name: "server-9"
+    build: .
+    ports:
+      - "230:22"
+    networks:
+      sake:
+        ipv6_address: 2001:3984:3989::10
+
+networks:
+  sake:
+    name: sake
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.24.2.0/16
+          gateway: 172.24.2.1
+
+        - subnet: 2001:3984:3989::/64
+          gateway: 2001:3984:3989::1

--- a/test/docker-compose-performance.yaml
+++ b/test/docker-compose-performance.yaml
@@ -4,7 +4,7 @@ version: "3.9"
 services:
   server-1:
     container_name: "server-1"
-    build: .
+    image: test_server-1
     ports:
       - "222:22"
     networks:
@@ -13,7 +13,7 @@ services:
 
   server-2:
     container_name: "server-2"
-    build: .
+    image: test_server-1
     ports:
       - "223:22"
     networks:
@@ -22,7 +22,7 @@ services:
 
   server-3:
     container_name: "server-3"
-    build: .
+    image: test_server-1
     ports:
       - "224:22"
     networks:
@@ -31,7 +31,7 @@ services:
 
   server-4:
     container_name: "server-4"
-    build: .
+    image: test_server-1
     ports:
       - "225:22"
     networks:
@@ -40,7 +40,7 @@ services:
 
   server-5:
     container_name: "server-5"
-    build: .
+    image: test_server-1
     ports:
       - "226:22"
     networks:
@@ -49,7 +49,7 @@ services:
 
   server-6:
     container_name: "server-6"
-    build: .
+    image: test_server-1
     ports:
       - "227:22"
     networks:
@@ -58,7 +58,7 @@ services:
 
   server-7:
     container_name: "server-7"
-    build: .
+    image: test_server-1
     ports:
       - "228:22"
     networks:
@@ -67,7 +67,7 @@ services:
 
   server-8:
     container_name: "server-8"
-    build: .
+    image: test_server-1
     ports:
       - "229:22"
     networks:
@@ -76,12 +76,831 @@ services:
 
   server-9:
     container_name: "server-9"
-    build: .
+    image: test_server-1
     ports:
       - "230:22"
     networks:
       sake:
-        ipv6_address: 2001:3984:3989::10
+        ipv4_address: 172.24.2.10
+
+  server-10:
+    container_name: "server-10"
+    image: test_server-1
+    ports:
+      - "231:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.11
+
+  server-11:
+    container_name: "server-11"
+    image: test_server-1
+    ports:
+      - "232:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.12
+
+  server-12:
+    container_name: "server-12"
+    image: test_server-1
+    ports:
+      - "233:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.13
+
+  server-13:
+    container_name: "server-13"
+    image: test_server-1
+    ports:
+      - "234:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.14
+
+  server-14:
+    container_name: "server-14"
+    image: test_server-1
+    ports:
+      - "235:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.15
+
+  server-15:
+    container_name: "server-15"
+    image: test_server-1
+    ports:
+      - "236:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.16
+
+  server-16:
+    container_name: "server-16"
+    image: test_server-1
+    ports:
+      - "237:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.17
+
+  server-17:
+    container_name: "server-17"
+    image: test_server-1
+    ports:
+      - "238:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.18
+
+  server-18:
+    container_name: "server-18"
+    image: test_server-1
+    ports:
+      - "239:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.19
+
+  server-19:
+    container_name: "server-19"
+    image: test_server-1
+    ports:
+      - "240:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.20
+
+  server-20:
+    container_name: "server-20"
+    image: test_server-1
+    ports:
+      - "241:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.21
+
+  server-21:
+    container_name: "server-21"
+    image: test_server-1
+    ports:
+      - "242:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.22
+
+  server-22:
+    container_name: "server-22"
+    image: test_server-1
+    ports:
+      - "243:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.23
+
+  server-23:
+    container_name: "server-23"
+    image: test_server-1
+    ports:
+      - "244:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.24
+
+  server-24:
+    container_name: "server-24"
+    image: test_server-1
+    ports:
+      - "245:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.25
+
+  server-25:
+    container_name: "server-25"
+    image: test_server-1
+    ports:
+      - "246:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.26
+
+  server-26:
+    container_name: "server-26"
+    image: test_server-1
+    ports:
+      - "247:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.27
+
+  server-27:
+    container_name: "server-27"
+    image: test_server-1
+    ports:
+      - "248:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.28
+
+  server-28:
+    container_name: "server-28"
+    image: test_server-1
+    ports:
+      - "249:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.29
+
+  server-29:
+    container_name: "server-29"
+    image: test_server-1
+    ports:
+      - "250:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.30
+
+  server-30:
+    container_name: "server-30"
+    image: test_server-1
+    ports:
+      - "251:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.31
+
+  server-31:
+    container_name: "server-31"
+    image: test_server-1
+    ports:
+      - "252:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.32
+
+  server-32:
+    container_name: "server-32"
+    image: test_server-1
+    ports:
+      - "253:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.33
+
+  server-33:
+    container_name: "server-33"
+    image: test_server-1
+    ports:
+      - "254:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.34
+
+  server-34:
+    container_name: "server-34"
+    image: test_server-1
+    ports:
+      - "255:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.35
+
+  server-35:
+    container_name: "server-35"
+    image: test_server-1
+    ports:
+      - "256:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.36
+
+  server-36:
+    container_name: "server-36"
+    image: test_server-1
+    ports:
+      - "257:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.37
+
+  server-37:
+    container_name: "server-37"
+    image: test_server-1
+    ports:
+      - "258:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.38
+
+  server-38:
+    container_name: "server-38"
+    image: test_server-1
+    ports:
+      - "259:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.39
+
+  server-39:
+    container_name: "server-39"
+    image: test_server-1
+    ports:
+      - "260:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.40
+
+  server-40:
+    container_name: "server-40"
+    image: test_server-1
+    ports:
+      - "261:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.41
+
+  server-41:
+    container_name: "server-41"
+    image: test_server-1
+    ports:
+      - "262:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.42
+
+  server-42:
+    container_name: "server-42"
+    image: test_server-1
+    ports:
+      - "263:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.43
+
+  server-43:
+    container_name: "server-43"
+    image: test_server-1
+    ports:
+      - "264:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.44
+
+  server-44:
+    container_name: "server-44"
+    image: test_server-1
+    ports:
+      - "265:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.45
+
+  server-45:
+    container_name: "server-45"
+    image: test_server-1
+    ports:
+      - "266:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.46
+
+  server-46:
+    container_name: "server-46"
+    image: test_server-1
+    ports:
+      - "267:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.47
+
+  server-47:
+    container_name: "server-47"
+    image: test_server-1
+    ports:
+      - "268:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.48
+
+  server-48:
+    container_name: "server-48"
+    image: test_server-1
+    ports:
+      - "269:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.49
+
+  server-49:
+    container_name: "server-49"
+    image: test_server-1
+    ports:
+      - "270:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.50
+
+  server-50:
+    container_name: "server-50"
+    image: test_server-1
+    ports:
+      - "271:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.51
+
+  server-51:
+    container_name: "server-51"
+    image: test_server-1
+    ports:
+      - "272:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.52
+
+  server-52:
+    container_name: "server-52"
+    image: test_server-1
+    ports:
+      - "273:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.53
+
+  server-53:
+    container_name: "server-53"
+    image: test_server-1
+    ports:
+      - "274:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.54
+
+  server-54:
+    container_name: "server-54"
+    image: test_server-1
+    ports:
+      - "275:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.55
+
+  server-55:
+    container_name: "server-55"
+    image: test_server-1
+    ports:
+      - "276:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.56
+
+  server-56:
+    container_name: "server-56"
+    image: test_server-1
+    ports:
+      - "277:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.57
+
+  server-57:
+    container_name: "server-57"
+    image: test_server-1
+    ports:
+      - "278:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.58
+
+  server-58:
+    container_name: "server-58"
+    image: test_server-1
+    ports:
+      - "279:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.59
+
+  server-59:
+    container_name: "server-59"
+    image: test_server-1
+    ports:
+      - "280:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.60
+
+  server-60:
+    container_name: "server-60"
+    image: test_server-1
+    ports:
+      - "281:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.61
+
+  server-61:
+    container_name: "server-61"
+    image: test_server-1
+    ports:
+      - "282:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.62
+
+  server-62:
+    container_name: "server-62"
+    image: test_server-1
+    ports:
+      - "283:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.63
+
+  server-63:
+    container_name: "server-63"
+    image: test_server-1
+    ports:
+      - "284:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.64
+
+  server-64:
+    container_name: "server-64"
+    image: test_server-1
+    ports:
+      - "285:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.65
+
+  server-65:
+    container_name: "server-65"
+    image: test_server-1
+    ports:
+      - "286:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.66
+
+  server-66:
+    container_name: "server-66"
+    image: test_server-1
+    ports:
+      - "287:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.67
+
+  server-67:
+    container_name: "server-67"
+    image: test_server-1
+    ports:
+      - "288:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.68
+
+  server-68:
+    container_name: "server-68"
+    image: test_server-1
+    ports:
+      - "289:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.69
+
+  server-69:
+    container_name: "server-69"
+    image: test_server-1
+    ports:
+      - "290:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.70
+
+  server-70:
+    container_name: "server-70"
+    image: test_server-1
+    ports:
+      - "291:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.71
+
+  server-71:
+    container_name: "server-71"
+    image: test_server-1
+    ports:
+      - "292:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.72
+
+  server-72:
+    container_name: "server-72"
+    image: test_server-1
+    ports:
+      - "293:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.73
+
+  server-73:
+    container_name: "server-73"
+    image: test_server-1
+    ports:
+      - "294:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.74
+
+  server-74:
+    container_name: "server-74"
+    image: test_server-1
+    ports:
+      - "295:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.75
+
+  server-75:
+    container_name: "server-75"
+    image: test_server-1
+    ports:
+      - "296:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.76
+
+  server-76:
+    container_name: "server-76"
+    image: test_server-1
+    ports:
+      - "297:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.77
+
+  server-77:
+    container_name: "server-77"
+    image: test_server-1
+    ports:
+      - "298:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.78
+
+  server-78:
+    container_name: "server-78"
+    image: test_server-1
+    ports:
+      - "299:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.79
+
+  server-79:
+    container_name: "server-79"
+    image: test_server-1
+    ports:
+      - "300:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.80
+
+  server-80:
+    container_name: "server-80"
+    image: test_server-1
+    ports:
+      - "301:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.81
+
+  server-81:
+    container_name: "server-81"
+    image: test_server-1
+    ports:
+      - "302:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.82
+
+  server-82:
+    container_name: "server-82"
+    image: test_server-1
+    ports:
+      - "303:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.83
+
+  server-83:
+    container_name: "server-83"
+    image: test_server-1
+    ports:
+      - "304:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.84
+
+  server-84:
+    container_name: "server-84"
+    image: test_server-1
+    ports:
+      - "305:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.85
+
+  server-85:
+    container_name: "server-85"
+    image: test_server-1
+    ports:
+      - "306:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.86
+
+  server-86:
+    container_name: "server-86"
+    image: test_server-1
+    ports:
+      - "307:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.87
+
+  server-87:
+    container_name: "server-87"
+    image: test_server-1
+    ports:
+      - "308:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.88
+
+  server-88:
+    container_name: "server-88"
+    image: test_server-1
+    ports:
+      - "309:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.89
+
+  server-89:
+    container_name: "server-89"
+    image: test_server-1
+    ports:
+      - "310:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.90
+
+  server-90:
+    container_name: "server-90"
+    image: test_server-1
+    ports:
+      - "311:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.91
+
+  server-91:
+    container_name: "server-91"
+    image: test_server-1
+    ports:
+      - "312:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.92
+
+  server-92:
+    container_name: "server-92"
+    image: test_server-1
+    ports:
+      - "313:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.93
+
+  server-93:
+    container_name: "server-93"
+    image: test_server-1
+    ports:
+      - "314:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.94
+
+  server-94:
+    container_name: "server-94"
+    image: test_server-1
+    ports:
+      - "315:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.95
+
+  server-95:
+    container_name: "server-95"
+    image: test_server-1
+    ports:
+      - "316:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.96
+
+  server-96:
+    container_name: "server-96"
+    image: test_server-1
+    ports:
+      - "317:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.97
+
+  server-97:
+    container_name: "server-97"
+    image: test_server-1
+    ports:
+      - "318:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.98
+
+  server-98:
+    container_name: "server-98"
+    image: test_server-1
+    ports:
+      - "319:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.99
+
+  server-99:
+    container_name: "server-99"
+    image: test_server-1
+    ports:
+      - "320:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.100
+
+  server-100:
+    container_name: "server-100"
+    image: test_server-1
+    ports:
+      - "321:22"
+    networks:
+      sake:
+        ipv4_address: 172.24.2.101
 
 networks:
   sake:
@@ -92,6 +911,3 @@ networks:
       config:
         - subnet: 172.24.2.0/16
           gateway: 172.24.2.1
-
-        - subnet: 2001:3984:3989::/64
-          gateway: 2001:3984:3989::1

--- a/test/playground/performance/sake.yaml
+++ b/test/playground/performance/sake.yaml
@@ -1,0 +1,741 @@
+disable_verify_host: true
+
+servers:
+  localhost:
+    desc: localhost
+    host: localhost
+    local: true
+    tags: [local]
+    work_dir: /opt
+
+  server-1:
+    desc: misc server hosting
+    host: 172.24.2.2
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-2:
+    desc: misc server hosting
+    host: 172.24.2.3
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-3:
+    desc: misc server hosting
+    host: 172.24.2.4
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-4:
+    desc: misc server hosting
+    host: 172.24.2.5
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_rsa_pem_no
+
+  server-5:
+    desc: misc server hosting
+    host: 172.24.2.6
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-6:
+    desc: misc server hosting
+    host: 172.24.2.7
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-7:
+    desc: misc server hosting
+    host: 172.24.2.8
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-8:
+    desc: misc server hosting
+    host: 172.24.2.9
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-9:
+    desc: misc server hosting
+    host: 172.24.2.10
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-10:
+    desc: misc server hosting
+    host: 172.24.2.11
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-11:
+    desc: misc server hosting
+    host: 172.24.2.12
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-12:
+    desc: misc server hosting
+    host: 172.24.2.13
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-13:
+    desc: misc server hosting
+    host: 172.24.2.14
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-14:
+    desc: misc server hosting
+    host: 172.24.2.15
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-15:
+    desc: misc server hosting
+    host: 172.24.2.16
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-16:
+    desc: misc server hosting
+    host: 172.24.2.17
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-17:
+    desc: misc server hosting
+    host: 172.24.2.18
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-18:
+    desc: misc server hosting
+    host: 172.24.2.19
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-19:
+    desc: misc server hosting
+    host: 172.24.2.20
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-20:
+    desc: misc server hosting
+    host: 172.24.2.21
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-21:
+    desc: misc server hosting
+    host: 172.24.2.22
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-22:
+    desc: misc server hosting
+    host: 172.24.2.23
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-23:
+    desc: misc server hosting
+    host: 172.24.2.24
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-24:
+    desc: misc server hosting
+    host: 172.24.2.25
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-25:
+    desc: misc server hosting
+    host: 172.24.2.26
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-26:
+    desc: misc server hosting
+    host: 172.24.2.27
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-27:
+    desc: misc server hosting
+    host: 172.24.2.28
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-28:
+    desc: misc server hosting
+    host: 172.24.2.29
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-29:
+    desc: misc server hosting
+    host: 172.24.2.30
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-30:
+    desc: misc server hosting
+    host: 172.24.2.31
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-31:
+    desc: misc server hosting
+    host: 172.24.2.32
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-32:
+    desc: misc server hosting
+    host: 172.24.2.33
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-33:
+    desc: misc server hosting
+    host: 172.24.2.34
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-34:
+    desc: misc server hosting
+    host: 172.24.2.35
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-35:
+    desc: misc server hosting
+    host: 172.24.2.36
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-36:
+    desc: misc server hosting
+    host: 172.24.2.37
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-37:
+    desc: misc server hosting
+    host: 172.24.2.38
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-38:
+    desc: misc server hosting
+    host: 172.24.2.39
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-39:
+    desc: misc server hosting
+    host: 172.24.2.40
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-40:
+    desc: misc server hosting
+    host: 172.24.2.41
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-41:
+    desc: misc server hosting
+    host: 172.24.2.42
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-42:
+    desc: misc server hosting
+    host: 172.24.2.43
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-43:
+    desc: misc server hosting
+    host: 172.24.2.44
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-44:
+    desc: misc server hosting
+    host: 172.24.2.45
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-45:
+    desc: misc server hosting
+    host: 172.24.2.46
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-46:
+    desc: misc server hosting
+    host: 172.24.2.47
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-47:
+    desc: misc server hosting
+    host: 172.24.2.48
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-48:
+    desc: misc server hosting
+    host: 172.24.2.49
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-49:
+    desc: misc server hosting
+    host: 172.24.2.50
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-50:
+    desc: misc server hosting
+    host: 172.24.2.51
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-51:
+    desc: misc server hosting
+    host: 172.24.2.52
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-52:
+    desc: misc server hosting
+    host: 172.24.2.53
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-53:
+    desc: misc server hosting
+    host: 172.24.2.54
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-54:
+    desc: misc server hosting
+    host: 172.24.2.55
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-55:
+    desc: misc server hosting
+    host: 172.24.2.56
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-56:
+    desc: misc server hosting
+    host: 172.24.2.57
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-57:
+    desc: misc server hosting
+    host: 172.24.2.58
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-58:
+    desc: misc server hosting
+    host: 172.24.2.59
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-59:
+    desc: misc server hosting
+    host: 172.24.2.60
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-60:
+    desc: misc server hosting
+    host: 172.24.2.61
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-61:
+    desc: misc server hosting
+    host: 172.24.2.62
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-62:
+    desc: misc server hosting
+    host: 172.24.2.63
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-63:
+    desc: misc server hosting
+    host: 172.24.2.64
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-64:
+    desc: misc server hosting
+    host: 172.24.2.65
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-65:
+    desc: misc server hosting
+    host: 172.24.2.66
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-66:
+    desc: misc server hosting
+    host: 172.24.2.67
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-67:
+    desc: misc server hosting
+    host: 172.24.2.68
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-68:
+    desc: misc server hosting
+    host: 172.24.2.69
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-69:
+    desc: misc server hosting
+    host: 172.24.2.70
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-70:
+    desc: misc server hosting
+    host: 172.24.2.71
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-71:
+    desc: misc server hosting
+    host: 172.24.2.72
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-72:
+    desc: misc server hosting
+    host: 172.24.2.73
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-73:
+    desc: misc server hosting
+    host: 172.24.2.74
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-74:
+    desc: misc server hosting
+    host: 172.24.2.75
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-75:
+    desc: misc server hosting
+    host: 172.24.2.76
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-76:
+    desc: misc server hosting
+    host: 172.24.2.77
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-77:
+    desc: misc server hosting
+    host: 172.24.2.78
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-78:
+    desc: misc server hosting
+    host: 172.24.2.79
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-79:
+    desc: misc server hosting
+    host: 172.24.2.80
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-80:
+    desc: misc server hosting
+    host: 172.24.2.81
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-81:
+    desc: misc server hosting
+    host: 172.24.2.82
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-82:
+    desc: misc server hosting
+    host: 172.24.2.83
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-83:
+    desc: misc server hosting
+    host: 172.24.2.84
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-84:
+    desc: misc server hosting
+    host: 172.24.2.85
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-85:
+    desc: misc server hosting
+    host: 172.24.2.86
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-86:
+    desc: misc server hosting
+    host: 172.24.2.87
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-87:
+    desc: misc server hosting
+    host: 172.24.2.88
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-88:
+    desc: misc server hosting
+    host: 172.24.2.89
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-89:
+    desc: misc server hosting
+    host: 172.24.2.90
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-90:
+    desc: misc server hosting
+    host: 172.24.2.91
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-91:
+    desc: misc server hosting
+    host: 172.24.2.92
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-92:
+    desc: misc server hosting
+    host: 172.24.2.93
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-93:
+    desc: misc server hosting
+    host: 172.24.2.94
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-94:
+    desc: misc server hosting
+    host: 172.24.2.95
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-95:
+    desc: misc server hosting
+    host: 172.24.2.96
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-96:
+    desc: misc server hosting
+    host: 172.24.2.97
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-97:
+    desc: misc server hosting
+    host: 172.24.2.98
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-98:
+    desc: misc server hosting
+    host: 172.24.2.99
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-99:
+    desc: misc server hosting
+    host: 172.24.2.100
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+  server-100:
+    desc: misc server hosting
+    host: 172.24.2.101
+    tags: [remote, pi]
+    user: test
+    identity_file: ../../keys/id_ed25519_pem_no
+
+targets:
+  all:
+    all: true
+
+specs:
+  table:
+    output: table
+
+  text:
+    output: text
+
+  info:
+    output: table
+    parallel: true
+    ignore_errors: true
+    ignore_unreachable: true
+    any_errors_fatal: false
+
+env:
+  VERSION: v0.1.0
+  DATE: $(date -u +"%Y-%m-%dT%H:%M:%S%Z")
+
+tasks:
+  exit:
+    local: true
+    cmd: exit 3
+
+  ping:
+    target: all
+    desc: ping server
+    cmd: echo pong

--- a/test/playground/sake.yaml
+++ b/test/playground/sake.yaml
@@ -9,20 +9,20 @@ servers:
     work_dir: /opt
 
   server-1:
-    desc: hosts mealie, node-red
+    desc: misc server hosting
     host: 172.24.2.2
     tags: [remote, pi]
     work_dir: /home/samir
 
   pihole-1:
-    desc: runs pihole
+    desc: pihole server
     host: 172.24.2.3
     tags: [remote, pi, pihole]
     user: test
     identity_file: ../keys/id_ed25519_pem_no
 
   pihole-2:
-    desc: runs pihole
+    desc: pihole server duplicate
     host: 172.24.2.3
     tags: [remote, pi, pihole]
     user: test

--- a/test/playground/sake.yaml
+++ b/test/playground/sake.yaml
@@ -12,7 +12,8 @@ servers:
     desc: misc server hosting
     host: 172.24.2.2
     tags: [remote, pi]
-    work_dir: /home/samir
+    user: test
+    identity_file: ../keys/id_ed25519_pem_no
 
   pihole-1:
     desc: pihole server


### PR DESCRIPTION
## What's Changed

Concerns https://github.com/alajmo/sake/issues/26

Fix connecting to many servers. Two issues were identified:
- Identity keys are tried for all servers resulting in too many auth failure
- ParsePrivateKeyWithPassphrase will be executed multiple times if multiple servers refer to the same identity file

## Technical Description

Currently, public keys defined for one server are also tried for other servers. This leads to:

```
ssh: handshake failed: ssh: disconnect, reason 2: Too many authentication failures
```

when many servers are defined.

