### PR TITLE
fix: respect invert flag in config

### DIFF
--- a/core/dao/task.go
+++ b/core/dao/task.go
@@ -376,12 +376,12 @@ func (c *Config) GetTaskServers(task *Task, runFlags *core.RunFlags, setRunFlags
 			return []Server{}, err
 		}
 		task.Target = *target
-		servers, err = c.FilterServers(task.Target.All, task.Target.Servers, task.Target.Tags, task.Target.Regex, runFlags.Invert)
+		servers, err = c.FilterServers(task.Target.All, task.Target.Servers, task.Target.Tags, task.Target.Regex, task.Target.Invert)
 		if err != nil {
 			return []Server{}, err
 		}
 	} else {
-		servers, err = c.FilterServers(task.Target.All, task.Target.Servers, task.Target.Tags, task.Target.Regex, runFlags.Invert)
+		servers, err = c.FilterServers(task.Target.All, task.Target.Servers, task.Target.Tags, task.Target.Regex, task.Target.Invert)
 		if err != nil {
 			return []Server{}, err
 		}


### PR DESCRIPTION
## What's Changed

Previously, the `invert` flag in the task configuration was ignored during task execution. This change honors the flag when set at the task target level.
